### PR TITLE
Improve iteration abilities of the map:

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ fn main() {
     assert_eq!(bitmap.set(3, true), false);
     assert_eq!(bitmap.len(), 2);
     assert_eq!(bitmap.first_index(), Some(3));
+    assert_eq!(bitmap.last_index(), Some(5));
 }
 ```
 


### PR DESCRIPTION
- Add [next/prev/last][_false]_index methods
- Make Iter double-ended
- Remove potential O(n) recursive calls overhead for iter.next()
- Ensure that we don't accidentally return values from wasted space from *_false_index-functions.

This fixes #13 