### PR TITLE
Fix overflow value in first_false_index()

### DIFF
--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -190,7 +190,7 @@ where
     /// Find the index of the first `false` bit in the bitmap.
     #[inline]
     pub fn first_false_index(self) -> Option<usize> {
-        <BitsImpl<SIZE> as Bits>::Store::first_false_index(&self.data)
+        <BitsImpl<SIZE> as Bits>::Store::first_false_index(&self.data).filter(|i| *i < SIZE)
     }
 
     /// Invert all the bits in the bitmap.


### PR DESCRIPTION
Previously, first_false_index() could have returned a value > SIZE

The following test was failing:
``` rust

  #[test]
    fn test_bitmap() {
        let mut a = Bitmap::<2>::new();
        a.set(0, true);
        a.set(1, true);
        assert_eq!(a.first_false_index(), None);
        assert_eq!(a.is_full(), true);
    }
```