### PR TITLE
Fix the `Bitmap::<32>::mask(32)` panic

### DIFF
--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -823,5 +823,8 @@ mod test {
         assert_eq!(Bitmap::<32>::mask(32).into_value(), u32::MAX);
         assert_eq!(Bitmap::<64>::mask(64).into_value(), u64::MAX);
         assert_eq!(Bitmap::<128>::mask(128).into_value(), u128::MAX);
+        assert!(Bitmap::<32>::mask(32).is_full());
+        assert!(Bitmap::<64>::mask(64).is_full());
+        assert!(Bitmap::<128>::mask(128).is_full());
     }
 }

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -801,5 +801,27 @@ mod test {
             let new_bitmap: Bitmap<1024> = TryFrom::try_from(bitmap.as_bytes()).expect("Unable to convert bitmap!");
             assert_eq!(new_bitmap, bitmap);
         }
+
+        #[test]
+        fn mask(shift in 0..=128usize) {
+            if shift <= 32 {
+                Bitmap::<32>::mask(shift);
+            }
+
+            if shift <= 64 {
+                Bitmap::<64>::mask(shift);
+            }
+
+            if shift <= 128 {
+                Bitmap::<128>::mask(shift);
+            }
+        }
+    }
+
+    #[test]
+    fn mask_limits() {
+        assert_eq!(Bitmap::<32>::mask(32).into_value(), u32::MAX);
+        assert_eq!(Bitmap::<64>::mask(64).into_value(), u64::MAX);
+        assert_eq!(Bitmap::<128>::mask(128).into_value(), u128::MAX);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -306,7 +306,8 @@ macro_rules! bitops_for {
 
             #[inline]
             fn make_mask(shift: usize) -> Self {
-                (1 << shift) - 1
+                let (x, overflow) = (1 as Self).overflowing_shl(shift as u32);
+                if overflow { Self::MAX } else { x - 1 }
             }
 
             #[cfg(feature = "std")]


### PR DESCRIPTION
Fixes the long-running issue #19.

@bodil 